### PR TITLE
ci: add Linux x86_64 binary to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,16 @@ permissions:
 jobs:
   build:
     name: Build ${{ matrix.target }}
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target:
-          - aarch64-apple-darwin
-          - x86_64-apple-darwin
+        include:
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
 
@@ -64,7 +68,8 @@ jobs:
             --title "${{ github.ref_name }}" \
             --generate-notes \
             dist/ccswitch-aarch64-apple-darwin.tar.gz \
-            dist/ccswitch-x86_64-apple-darwin.tar.gz
+            dist/ccswitch-x86_64-apple-darwin.tar.gz \
+            dist/ccswitch-x86_64-unknown-linux-gnu.tar.gz
 
       - name: Update Homebrew formula
         env:


### PR DESCRIPTION
Adds `x86_64-unknown-linux-gnu` to the build matrix and attaches the resulting tarball to the GitHub release alongside the macOS artifacts.

Closes #4