### PR TITLE
feat: add shell completion generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "crossterm",
  "dirs",
@@ -185,6 +186,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "color"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ pub(crate) mod test_utils {
 }
 
 use anyhow::Result;
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use colored::Colorize;
 
 #[derive(Parser)]
@@ -96,6 +96,12 @@ enum Commands {
         /// Short name to use as the alias (e.g. "work", "personal")
         name: String,
     },
+
+    /// Generate shell completion script
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
 }
 
 fn main() {
@@ -131,5 +137,9 @@ fn run() -> Result<()> {
             accounts::refresh(account.as_deref())
         }
         Some(Commands::Alias { account, name }) => accounts::set_alias(&account, &name),
+        Some(Commands::Completions { shell }) => {
+            clap_complete::generate(shell, &mut Cli::command(), "ccswitch", &mut std::io::stdout());
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
Adds `ccswitch completions <shell>` subcommand that prints a completion script to stdout.

Supported shells: bash, zsh, fish, powershell, elvish (via clap_complete).

Usage:
```
# zsh
ccswitch completions zsh > ~/.zfunc/_ccswitch

# bash
ccswitch completions bash > /etc/bash_completion.d/ccswitch

# fish
ccswitch completions fish > ~/.config/fish/completions/ccswitch.fish
```

Closes #6