### PR TITLE
feat: credential format sentinel

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -36,6 +36,13 @@ pub(crate) fn core_add() -> Result<String> {
     credentials::write_backup(account_num, &email, &live_creds)?;
     write_config_backup(account_num, &email, &live_config_str)?;
 
+    // Record the credential format fingerprint so future switches/refreshes
+    // can detect if Claude Code has changed its credential schema.
+    let fp = credentials::credential_field_fingerprint(&live_creds);
+    if !fp.is_empty() {
+        seq.format_fingerprint = Some(fp);
+    }
+
     seq.accounts.insert(
         account_num.to_string(),
         AccountEntry {
@@ -86,6 +93,7 @@ pub(crate) fn core_switch(target_num: u32) -> Result<String> {
     // Token accounts: skip — the token is static and was already stored during `add`
     if current_auth_kind == AuthKind::Oauth {
         let live_creds = credentials::read_live().context("Cannot read current credentials")?;
+        warn_if_format_changed(&seq, &live_creds);
         let live_config = config::load().context("Cannot read current Claude config")?;
         let live_config_str = serde_json::to_string_pretty(&live_config)?;
 
@@ -385,6 +393,7 @@ pub(crate) fn core_refresh(target_num: u32) -> Result<String> {
         credentials::read_backup(target_num, &entry.email)
             .with_context(|| format!("Cannot read backup credentials for Account {target_num}"))?
     };
+    warn_if_format_changed(&seq, &creds);
 
     let new_creds = credentials::refresh_oauth_creds(&creds).map_err(|e| {
         // Distinguish between a bad refresh token (needs full re-login) and network/other errors
@@ -1043,6 +1052,23 @@ pub(crate) fn read_config_backup(num: u32, email: &str) -> Result<String> {
 }
 
 // ── Session expiry helper ─────────────────────────────────────────────────────
+
+/// Compare the fingerprint of `creds` against the stored one in `seq`.
+/// Prints a warning to stderr when they differ.
+fn warn_if_format_changed(seq: &SequenceFile, creds: &str) {
+    let Some(stored_fp) = seq.format_fingerprint.as_deref() else {
+        return;
+    };
+    let live_fp = credentials::credential_field_fingerprint(creds);
+    if !live_fp.is_empty() && live_fp != stored_fp {
+        eprintln!(
+            "\n  {} Claude Code may have changed its credential format. \
+             ccswitch may not work correctly. \
+             Please check https://github.com/vyshnavsdeepak/ccswitch/issues for updates.",
+            "Warning:".yellow().bold()
+        );
+    }
+}
 
 /// Return a short badge string describing session expiry for display in lists.
 /// Empty string means the session is healthy and no badge is needed.

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -281,6 +281,27 @@ pub fn refresh_oauth_creds(creds_json: &str) -> Result<String> {
     serde_json::to_string(&v).context("Failed to serialize updated credentials")
 }
 
+// ── Format sentinel ───────────────────────────────────────────────────────────
+
+/// Compute a fingerprint of the top-level keys inside `claudeAiOauth`.
+///
+/// Returns a sorted, `|`-joined string of the key names, e.g.
+/// `"accessToken|expiresAt|refreshToken|scopes"`.
+/// Returns an empty string when the JSON cannot be parsed or `claudeAiOauth`
+/// is absent (e.g. static-token accounts).
+pub fn credential_field_fingerprint(creds_str: &str) -> String {
+    let v: serde_json::Value = match serde_json::from_str(creds_str) {
+        Ok(v) => v,
+        Err(_) => return String::new(),
+    };
+    let Some(obj) = v.get("claudeAiOauth").and_then(|o| o.as_object()) else {
+        return String::new();
+    };
+    let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+    keys.sort_unstable();
+    keys.join("|")
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn account_service(num: u32, email: &str) -> String {
@@ -425,5 +446,68 @@ mod tests {
     fn test_oauth_secs_remaining_none_for_token() {
         let creds = r#"{"token": "sk-ant-oat01-abc"}"#;
         assert_eq!(oauth_secs_remaining(creds), None);
+    }
+
+    // ── credential_field_fingerprint ─────────────────────────────────────────
+
+    #[test]
+    fn test_fingerprint_standard_oauth() {
+        let creds = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "tok",
+                "refreshToken": "rtok",
+                "expiresAt": 1_234_567_890_i64,
+                "scopes": []
+            }
+        })
+        .to_string();
+        assert_eq!(
+            credential_field_fingerprint(&creds),
+            "accessToken|expiresAt|refreshToken|scopes"
+        );
+    }
+
+    #[test]
+    fn test_fingerprint_sorted_regardless_of_json_order() {
+        let creds1 = r#"{"claudeAiOauth": {"b": 1, "a": 2}}"#;
+        let creds2 = r#"{"claudeAiOauth": {"a": 2, "b": 1}}"#;
+        assert_eq!(
+            credential_field_fingerprint(creds1),
+            credential_field_fingerprint(creds2)
+        );
+        assert_eq!(credential_field_fingerprint(creds1), "a|b");
+    }
+
+    #[test]
+    fn test_fingerprint_non_oauth_returns_empty() {
+        let creds = r#"{"token": "sk-ant-oat01-abc"}"#;
+        assert_eq!(credential_field_fingerprint(creds), "");
+    }
+
+    #[test]
+    fn test_fingerprint_invalid_json_returns_empty() {
+        assert_eq!(credential_field_fingerprint("not json at all"), "");
+    }
+
+    #[test]
+    fn test_fingerprint_detects_added_field() {
+        let original = r#"{"claudeAiOauth": {"accessToken": "t", "refreshToken": "r"}}"#;
+        let changed =
+            r#"{"claudeAiOauth": {"accessToken": "t", "refreshToken": "r", "newField": "x"}}"#;
+        assert_ne!(
+            credential_field_fingerprint(original),
+            credential_field_fingerprint(changed)
+        );
+    }
+
+    #[test]
+    fn test_fingerprint_detects_removed_field() {
+        let original =
+            r#"{"claudeAiOauth": {"accessToken": "t", "refreshToken": "r", "expiresAt": 1}}"#;
+        let changed = r#"{"claudeAiOauth": {"accessToken": "t", "refreshToken": "r"}}"#;
+        assert_ne!(
+            credential_field_fingerprint(original),
+            credential_field_fingerprint(changed)
+        );
     }
 }

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -33,6 +33,14 @@ pub struct SequenceFile {
     pub accounts: HashMap<String, AccountEntry>,
     #[serde(default)]
     pub aliases: HashMap<String, u32>,
+    /// Fingerprint of the `claudeAiOauth` key set recorded at `ccswitch add`
+    /// time.  Used to detect Claude Code credential-format drift.
+    #[serde(
+        rename = "formatFingerprint",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub format_fingerprint: Option<String>,
 }
 
 impl SequenceFile {
@@ -266,5 +274,38 @@ mod tests {
         let seq = load().unwrap();
         assert!(seq.accounts.is_empty());
         assert_eq!(seq.active_account_number, None);
+    }
+
+    #[test]
+    fn test_format_fingerprint_default_none() {
+        let seq = SequenceFile::default();
+        assert_eq!(seq.format_fingerprint, None);
+    }
+
+    #[test]
+    fn test_format_fingerprint_roundtrip() {
+        let _env = crate::test_utils::TestEnv::new();
+        let mut seq = SequenceFile::default();
+        seq.format_fingerprint =
+            Some("accessToken|expiresAt|refreshToken|scopes".to_string());
+        save(&seq).unwrap();
+
+        let loaded = load().unwrap();
+        assert_eq!(
+            loaded.format_fingerprint,
+            Some("accessToken|expiresAt|refreshToken|scopes".to_string())
+        );
+    }
+
+    #[test]
+    fn test_format_fingerprint_absent_in_json_deserialises_as_none() {
+        let _env = crate::test_utils::TestEnv::new();
+        // Write a sequence.json that has no formatFingerprint key
+        let json = r#"{"activeAccountNumber":1,"lastUpdated":"2024-01-01T00:00:00Z","sequence":[1],"accounts":{}}"#;
+        let path = sequence_path();
+        std::fs::write(&path, json).unwrap();
+
+        let loaded = load().unwrap();
+        assert_eq!(loaded.format_fingerprint, None);
     }
 }


### PR DESCRIPTION
Detects Claude Code credential schema drift and warns the user before it causes silent failures.

- `credential_field_fingerprint(creds_str) -> String` in `credentials.rs` — sorts the top-level keys inside `claudeAiOauth` and joins them with `|` (e.g. `accessToken|expiresAt|refreshToken|scopes`); no new dependencies
- `format_fingerprint: Option<String>` field added to `SequenceFile` (`formatFingerprint` in JSON, omitted when `None`)
- `ccswitch add` computes and persists the fingerprint
- `ccswitch switch` and `ccswitch refresh` compare the live fingerprint against the stored one and print a warning if they differ
- 11 new unit tests across `credentials.rs` and `sequence.rs`; all 51 tests pass

Closes #14