### PR TITLE
feat: interactive re-auth on refresh-token expiry

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -359,6 +359,68 @@ fn token_default_label() -> String {
     format!("token-{:08X}", ts)
 }
 
+// ── Re-auth helpers ───────────────────────────────────────────────────────────
+
+/// Returns true if the error is caused by an expired/revoked refresh token
+/// (OAuth `invalid_grant`).
+pub(crate) fn is_invalid_grant_error(e: &anyhow::Error) -> bool {
+    let msg = e.to_string();
+    msg.contains("invalid_grant") || msg.contains("Refresh token expired")
+}
+
+/// Interactive CLI prompt shown when a refresh token is permanently invalid.
+/// Prints re-auth instructions, then offers to remove the account.
+pub(crate) fn interactive_reauth_prompt(num: u32, email: &str) -> Result<()> {
+    println!();
+    println!(
+        "  {} Refresh token for Account {} ({}) has expired (invalid_grant).",
+        "!".red().bold(),
+        num,
+        email.yellow()
+    );
+    println!(
+        "  {} The token cannot be renewed automatically — \
+         you need to log in again.",
+        " ".normal()
+    );
+    println!();
+    println!("  To re-authenticate this account:");
+    println!(
+        "    {}  {}  {}",
+        "1.".cyan().bold(),
+        "Switch to it:   ",
+        format!("ccswitch switch {}", num).cyan().bold()
+    );
+    println!(
+        "    {}  {}",
+        "2.".cyan().bold(),
+        "Open Claude Code and log in (run: claude)"
+    );
+    println!(
+        "    {}  {}  {}",
+        "3.".cyan().bold(),
+        "Save the session:",
+        "ccswitch add".cyan().bold()
+    );
+    println!();
+
+    print!("  Remove Account {} ({}) now? [y/N] ", num, email);
+    io::stdout().flush()?;
+
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+
+    if matches!(input.trim(), "y" | "Y") {
+        let msg = core_remove(num, email)?;
+        println!("\n  {} {}", "✓".green().bold(), msg);
+    } else {
+        println!("  {} Kept — re-authenticate when ready.", "·".dimmed());
+    }
+    println!();
+
+    Ok(())
+}
+
 // ── Refresh OAuth token ───────────────────────────────────────────────────────
 
 pub(crate) fn core_refresh(target_num: u32) -> Result<String> {
@@ -438,8 +500,20 @@ pub fn refresh(identifier: Option<&str>, all: bool) -> Result<()> {
     };
 
     println!();
-    let msg = core_refresh(target_num)?;
-    println!("  {} {}\n", "✓".green().bold(), msg);
+    match core_refresh(target_num) {
+        Ok(msg) => {
+            println!("  {} {}\n", "✓".green().bold(), msg);
+        }
+        Err(e) if is_invalid_grant_error(&e) => {
+            let email = seq
+                .accounts
+                .get(&target_num.to_string())
+                .map(|entry| entry.email.clone())
+                .unwrap_or_default();
+            interactive_reauth_prompt(target_num, &email)?;
+        }
+        Err(e) => return Err(e),
+    }
     Ok(())
 }
 
@@ -1072,6 +1146,32 @@ mod tests {
         test_utils::TestEnv,
     };
     use std::fs;
+
+    // ── is_invalid_grant_error ────────────────────────────────────────────────
+
+    #[test]
+    fn test_is_invalid_grant_error_http_response() {
+        let e = anyhow::anyhow!("Token refresh failed (HTTP 400): invalid_grant: Refresh token not found");
+        assert!(is_invalid_grant_error(&e));
+    }
+
+    #[test]
+    fn test_is_invalid_grant_error_transformed_message() {
+        let e = anyhow::anyhow!("Refresh token expired for Account 2 (user@test.com).");
+        assert!(is_invalid_grant_error(&e));
+    }
+
+    #[test]
+    fn test_is_invalid_grant_error_network_error() {
+        let e = anyhow::anyhow!("Token refresh request failed: connection refused");
+        assert!(!is_invalid_grant_error(&e));
+    }
+
+    #[test]
+    fn test_is_invalid_grant_error_http_500() {
+        let e = anyhow::anyhow!("Token refresh failed (HTTP 500): internal server error");
+        assert!(!is_invalid_grant_error(&e));
+    }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,6 +26,8 @@ enum Mode {
     ConfirmSwitch { num: u32, email: String },
     ConfirmRemove { num: u32, email: String },
     ConfirmAdd { email: String },
+    /// Shown when a refresh attempt fails with invalid_grant (expired refresh token).
+    ExpiredAccount { num: u32, email: String },
     /// Switch (or other action) completed.
     Done,
 }
@@ -153,6 +155,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                 Mode::ConfirmSwitch { .. }
                 | Mode::ConfirmRemove { .. }
                 | Mode::ConfirmAdd { .. } => handle_confirm(&mut app, key.code)?,
+                Mode::ExpiredAccount { .. } => handle_expired(&mut app, key.code)?,
                 Mode::Done => {
                     app.quit = true;
                 }
@@ -239,6 +242,41 @@ fn handle_normal(app: &mut App, key: KeyCode) -> Result<()> {
                 // No OAuth account — suspend TUI and run the interactive add flow
                 // (covers token accounts and fresh installs where the user pastes a token).
                 app.pending_token_add = true;
+            }
+        }
+        KeyCode::Char('r') => {
+            if let Some(num) = app.selected_num() {
+                if let Some(entry) = app.seq.accounts.get(&num.to_string()) {
+                    let email = entry.email.clone();
+                    if entry.auth_kind == AuthKind::Oauth {
+                        match accounts::core_refresh(num) {
+                            Ok(msg) => {
+                                app.reload()?;
+                                app.flash = Some(Flash {
+                                    message: msg,
+                                    is_error: false,
+                                });
+                            }
+                            Err(e) if accounts::is_invalid_grant_error(&e) => {
+                                app.mode = Mode::ExpiredAccount { num, email };
+                            }
+                            Err(e) => {
+                                app.flash = Some(Flash {
+                                    message: format!(
+                                        "Refresh failed: {}",
+                                        e.to_string().lines().next().unwrap_or("error")
+                                    ),
+                                    is_error: true,
+                                });
+                            }
+                        }
+                    } else {
+                        app.flash = Some(Flash {
+                            message: "Token accounts don't use refresh tokens".to_string(),
+                            is_error: false,
+                        });
+                    }
+                }
             }
         }
         KeyCode::Char('d') | KeyCode::Delete => {
@@ -330,6 +368,28 @@ fn handle_confirm(app: &mut App, key: KeyCode) -> Result<()> {
     Ok(())
 }
 
+fn handle_expired(app: &mut App, key: KeyCode) -> Result<()> {
+    match key {
+        KeyCode::Char('d') | KeyCode::Delete => {
+            // Reuse the existing ConfirmRemove flow for the actual deletion.
+            let (num, email) = match &app.mode {
+                Mode::ExpiredAccount { num, email } => (*num, email.clone()),
+                _ => return Ok(()),
+            };
+            app.mode = Mode::ConfirmRemove { num, email };
+        }
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.mode = Mode::Normal;
+            app.flash = Some(Flash {
+                message: "Re-auth: ccswitch switch <n>  →  claude  →  ccswitch add".to_string(),
+                is_error: false,
+            });
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 // ── UI rendering ──────────────────────────────────────────────────────────────
 
 fn ui(f: &mut ratatui::Frame, app: &mut App) {
@@ -379,6 +439,9 @@ fn ui(f: &mut ratatui::Frame, app: &mut App) {
                 email,
                 Color::Yellow,
             );
+        }
+        Mode::ExpiredAccount { num, email } => {
+            render_expired_dialog(f, area, *num, email);
         }
         _ => {}
     }
@@ -567,7 +630,7 @@ fn render_help(f: &mut ratatui::Frame, app: &App, area: Rect) {
                 ])
             } else {
                 Line::from(vec![Span::styled(
-                    "  ↑↓ nav  ·  ↵ switch  ·  a add  ·  d remove  ·  q quit",
+                    "  ↑↓ nav  ·  ↵ switch  ·  a add  ·  d remove  ·  r refresh  ·  q quit",
                     Style::default().fg(Color::DarkGray),
                 )])
             };
@@ -632,6 +695,64 @@ fn render_confirm_dialog(
             ),
             Span::styled(
                 "      [n / Esc] cancel",
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+    ];
+
+    let para = Paragraph::new(text).alignment(Alignment::Left);
+    f.render_widget(para, inner);
+}
+
+fn render_expired_dialog(f: &mut ratatui::Frame, area: Rect, num: u32, email: &str) {
+    let dialog_width = 66u16;
+    let dialog_height = 10u16;
+
+    let x = area.x + area.width.saturating_sub(dialog_width) / 2;
+    let y = area.y + area.height.saturating_sub(dialog_height) / 2;
+
+    let dialog_area = Rect {
+        x,
+        y,
+        width: dialog_width.min(area.width),
+        height: dialog_height.min(area.height),
+    };
+
+    f.render_widget(Clear, dialog_area);
+
+    let block = Block::default()
+        .title(" Expired Refresh Token ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(Color::Red));
+
+    let inner = block.inner(dialog_area);
+    f.render_widget(block, dialog_area);
+
+    let text = vec![
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            format!("   Account {}  ({})", num, email),
+            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "   Refresh token is invalid — re-authentication required.",
+            Style::default().fg(Color::White),
+        )]),
+        Line::from(""),
+        Line::from(vec![Span::styled(
+            "   Re-add:  ccswitch switch N  →  claude  →  ccswitch add",
+            Style::default().fg(Color::Cyan),
+        )]),
+        Line::from(""),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "   [d] remove account",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                "      [Esc] cancel",
                 Style::default().fg(Color::DarkGray),
             ),
         ]),


### PR DESCRIPTION
Closes #15

## Changes

**`src/accounts.rs`**
- `is_invalid_grant_error(e)` — detects `invalid_grant` / `Refresh token expired` errors
- `interactive_reauth_prompt(num, email)` — prints step-by-step re-auth instructions, then offers `[y/N]` to remove the account immediately
- `refresh()` — single-account path now catches `invalid_grant` and calls the interactive prompt instead of hard-failing

**`src/tui.rs`**
- `Mode::ExpiredAccount { num, email }` — new modal shown when refreshing an account fails with `invalid_grant`; offers `[d]` to remove or `[Esc]` to cancel with instructions in the flash bar
- `'r'` key added to Normal mode — tries `core_refresh` on the selected account, transitions to `ExpiredAccount` on `invalid_grant`, or shows a flash on other errors
- Help bar updated to include `r refresh`

**Tests** — 4 new unit tests for `is_invalid_grant_error`; all 46 tests pass.