### PR TITLE
ci: add release workflow with platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,11 @@ jobs:
           X86_SHA: ${{ steps.sha.outputs.x86 }}
         run: |
           sed -i \
-            -e "s|VERSION_PLACEHOLDER|${VERSION#v}|g" \
-            -e "s|TAG_PLACEHOLDER|${VERSION}|g" \
-            -e "s|ARM_SHA_PLACEHOLDER|${ARM_SHA}|g" \
-            -e "s|X86_SHA_PLACEHOLDER|${X86_SHA}|g" \
+            -e "s|version \"[^\"]*\" # VERSION|version \"${VERSION#v}\" # VERSION|" \
+            -e "s|download/v[^/]*/ccswitch-aarch64-apple-darwin.tar.gz\" # ARM_URL|download/${VERSION}/ccswitch-aarch64-apple-darwin.tar.gz\" # ARM_URL|" \
+            -e "s|sha256 \"[^\"]*\" # ARM_SHA|sha256 \"${ARM_SHA}\" # ARM_SHA|" \
+            -e "s|download/v[^/]*/ccswitch-x86_64-apple-darwin.tar.gz\" # X86_URL|download/${VERSION}/ccswitch-x86_64-apple-darwin.tar.gz\" # X86_URL|" \
+            -e "s|sha256 \"[^\"]*\" # X86_SHA|sha256 \"${X86_SHA}\" # X86_SHA|" \
             Formula/ccswitch.rb
 
       - name: Commit formula update

--- a/Formula/ccswitch.rb
+++ b/Formula/ccswitch.rb
@@ -1,18 +1,18 @@
 class Ccswitch < Formula
   desc "Multi-account switcher for Claude Code"
   homepage "https://github.com/vyshnavsdeepak/ccswitch"
-  version "0.1.0"
+  version "0.2.0" # VERSION
   license "MIT"
 
   on_macos do
     on_arm do
-      url "https://github.com/vyshnavsdeepak/ccswitch/releases/download/v0.1.0/ccswitch-aarch64-apple-darwin.tar.gz"
-      sha256 "13aa687fcc2f79b897b999c808b0cda4821b18995861335bcd4114b67ed9b60e"
+      url "https://github.com/vyshnavsdeepak/ccswitch/releases/download/v0.2.0/ccswitch-aarch64-apple-darwin.tar.gz" # ARM_URL
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000" # ARM_SHA
     end
 
     on_intel do
-      url "https://github.com/vyshnavsdeepak/ccswitch/releases/download/v0.1.0/ccswitch-x86_64-apple-darwin.tar.gz"
-      sha256 "590f08b238d9d7a7dc3cf45eef64170c0816a37975d11b68de26ca2293e8b7f5"
+      url "https://github.com/vyshnavsdeepak/ccswitch/releases/download/v0.2.0/ccswitch-x86_64-apple-darwin.tar.gz" # X86_URL
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000" # X86_SHA
     end
   end
 


### PR DESCRIPTION
Builds and uploads release assets for three targets on `v*` tag push:

- `ccswitch-aarch64-apple-darwin.tar.gz`
- `ccswitch-x86_64-apple-darwin.tar.gz`
- `ccswitch-x86_64-unknown-linux-gnu.tar.gz`

After upload, the workflow updates `Formula/ccswitch.rb` with the real version and SHA256 checksums, then commits back to main. The formula uses comment-tagged markers (`# VERSION`, `# ARM_SHA`, etc.) so the `sed` replacements are idempotent across releases — no stale one-time placeholders.

Closes #22