### PR TITLE
feat: encrypted Gist relay for export/import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,16 +153,20 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "clap_complete",
  "colored",
  "crossterm",
  "dirs",
+ "pbkdf2",
+ "rand",
  "ratatui",
  "rpassword",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "ureq",
 ]
@@ -153,6 +176,30 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "chrono"
@@ -165,6 +212,17 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -253,6 +311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +354,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +396,17 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -412,6 +501,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +556,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -615,6 +723,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -781,6 +898,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -816,10 +939,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -828,6 +972,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -863,6 +1016,36 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -1069,6 +1252,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,6 +1468,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -1316,6 +1526,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1791,6 +2007,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ crossterm = "0.28"
 rpassword = "7"
 ureq = { version = "2", features = ["json"] }
 base64 = "0.22"
+chacha20poly1305 = "0.10"
+pbkdf2 = { version = "0.12", features = ["hmac"] }
+sha2 = "0.10"
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,10 +137,17 @@ enum Commands {
         account: Option<String>,
         #[arg(long)]
         all: bool,
+        /// Upload encrypted blob to a private GitHub Gist and print the import command
+        #[arg(long)]
+        gist: bool,
     },
 
     /// Import accounts from an export blob (reads interactively — no shell history)
-    Import,
+    Import {
+        /// Download and decrypt from a GitHub Gist created by `export --gist`
+        #[arg(long, value_name = "ID")]
+        gist: Option<String>,
+    },
 }
 
 fn main() {
@@ -183,7 +190,13 @@ fn run() -> Result<()> {
         }
         Some(Commands::Doctor) => accounts::doctor(),
         Some(Commands::Update) => update::update(),
-        Some(Commands::Export { account, all }) => transfer::export(account.as_deref(), all),
-        Some(Commands::Import) => transfer::import(),
+        Some(Commands::Export { account, all, gist: true }) => {
+            transfer::export_gist(account.as_deref(), all)
+        }
+        Some(Commands::Export { account, all, gist: false }) => {
+            transfer::export(account.as_deref(), all)
+        }
+        Some(Commands::Import { gist: Some(id) }) => transfer::import_gist(&id),
+        Some(Commands::Import { gist: None }) => transfer::import(),
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -1,8 +1,13 @@
 use anyhow::{Context, Result};
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{ChaCha20Poly1305, Key, Nonce};
 use colored::Colorize;
+use pbkdf2::pbkdf2_hmac;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
+use sha2::Sha256;
 
 use crate::{accounts, credentials, sequence};
 
@@ -36,9 +41,84 @@ fn default_empty_object() -> String {
     "{}".to_string()
 }
 
+// ── crypto helpers ─────────────────────────────────────────────────────────────
+
+/// Encrypt `plaintext` with passphrase using PBKDF2-SHA256 + ChaCha20-Poly1305.
+/// Returns `base64(salt[16] ++ nonce[12] ++ ciphertext+tag)`.
+fn encrypt(plaintext: &[u8], passphrase: &str) -> Result<String> {
+    let mut salt = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut salt);
+
+    let mut key_bytes = [0u8; 32];
+    pbkdf2_hmac::<Sha256>(passphrase.as_bytes(), &salt, 100_000, &mut key_bytes);
+
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|e| anyhow::anyhow!("Encryption failed: {}", e))?;
+
+    let mut bundle = Vec::with_capacity(16 + 12 + ciphertext.len());
+    bundle.extend_from_slice(&salt);
+    bundle.extend_from_slice(&nonce_bytes);
+    bundle.extend_from_slice(&ciphertext);
+
+    Ok(STANDARD.encode(&bundle))
+}
+
+/// Decrypt a bundle produced by `encrypt()`.
+fn decrypt(encoded: &str, passphrase: &str) -> Result<Vec<u8>> {
+    let bundle = STANDARD
+        .decode(encoded.trim().as_bytes())
+        .context("Invalid base64 in encrypted blob")?;
+
+    // minimum: 16 (salt) + 12 (nonce) + 16 (Poly1305 tag, empty plaintext)
+    if bundle.len() < 44 {
+        anyhow::bail!("Encrypted blob is too short");
+    }
+
+    let (salt, rest) = bundle.split_at(16);
+    let (nonce_bytes, ciphertext) = rest.split_at(12);
+
+    let mut key_bytes = [0u8; 32];
+    pbkdf2_hmac::<Sha256>(passphrase.as_bytes(), salt, 100_000, &mut key_bytes);
+
+    let cipher = ChaCha20Poly1305::new(Key::from_slice(&key_bytes));
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| anyhow::anyhow!("Decryption failed — wrong passphrase?"))
+}
+
+// ── GitHub CLI helper ──────────────────────────────────────────────────────────
+
+fn gh_token() -> Result<String> {
+    let output = std::process::Command::new("gh")
+        .args(["auth", "token"])
+        .output()
+        .context("Failed to run `gh auth token` — is the GitHub CLI installed?\nInstall from https://cli.github.com")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "GitHub CLI not authenticated. Run `gh auth login` first.\n{}",
+            stderr.trim()
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
 // ── export ────────────────────────────────────────────────────────────────────
 
-pub fn export(account: Option<&str>, all: bool) -> Result<()> {
+/// Build the export payload (accounts list + metadata) without deciding where to send it.
+fn build_export_payload(account: Option<&str>, all: bool) -> Result<ExportPayload> {
+    #[allow(unused_imports)]
     use std::io::IsTerminal;
 
     if all && account.is_some() {
@@ -50,7 +130,6 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
         anyhow::bail!("No managed accounts found. Run `ccswitch add` first.");
     }
 
-    // Collect account numbers to export.
     let nums: Vec<u32> = if all {
         seq.sequence.clone()
     } else if let Some(id) = account {
@@ -59,7 +138,6 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
             .with_context(|| format!("Account '{id}' not found"))?;
         vec![num]
     } else if std::io::stdin().is_terminal() {
-        // Interactive picker — show the account list and let the user choose.
         pick_accounts_interactive(&seq)?
     } else {
         let num = seq
@@ -68,16 +146,11 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
         vec![num]
     };
 
-    // Determine active_num for the payload.
-    // Only use the global active account if it is actually in the export set;
-    // otherwise fall back to the first exported account (e.g. --account 2 while
-    // account 1 is active should mark account 2 as active in the blob).
     let active_num = seq
         .active_account_number
         .filter(|n| nums.contains(n))
         .unwrap_or(nums[0]);
 
-    // Build account export entries.
     let mut account_exports: Vec<AccountExport> = Vec::new();
     for &num in &nums {
         let entry = seq
@@ -102,21 +175,24 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
         });
     }
 
-    // Compute format fingerprint from the active account's credentials.
     let format_fingerprint = account_exports
         .iter()
         .find(|a| a.num == active_num)
         .map(|a| credentials::credential_field_fingerprint(&a.credentials))
         .filter(|fp| !fp.is_empty());
 
-    let payload = ExportPayload {
+    Ok(ExportPayload {
         version: 1,
         exported_at: sequence::now_utc(),
         active_num,
         format_fingerprint,
         accounts: account_exports,
-    };
+    })
+}
 
+pub fn export(account: Option<&str>, all: bool) -> Result<()> {
+    use std::io::IsTerminal;
+    let payload = build_export_payload(account, all)?;
     let json = serde_json::to_string(&payload).context("Failed to serialize export payload")?;
     let blob = STANDARD.encode(json.as_bytes());
 
@@ -136,7 +212,6 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
             "ccswitch import".cyan().bold()
         );
     } else {
-        // Clipboard not available — warn and fall back to file.
         #[cfg(not(target_os = "macos"))]
         eprintln!(
             "  {}  No clipboard tool found (tried wl-copy, xclip, xsel).",
@@ -148,14 +223,51 @@ pub fn export(account: Option<&str>, all: bool) -> Result<()> {
     Ok(())
 }
 
+pub fn export_gist(account: Option<&str>, all: bool) -> Result<()> {
+    let payload = build_export_payload(account, all)?;
+    let json = serde_json::to_string(&payload).context("Failed to serialize export payload")?;
+
+    let passphrase = rpassword::prompt_password("  Passphrase (to encrypt): ")
+        .context("Failed to read passphrase")?;
+    if passphrase.is_empty() {
+        anyhow::bail!("Passphrase must not be empty");
+    }
+
+    let encrypted = encrypt(json.as_bytes(), &passphrase)?;
+
+    let token = gh_token()?;
+
+    let resp = ureq::post("https://api.github.com/gists")
+        .set("Authorization", &format!("Bearer {}", token))
+        .set("User-Agent", "ccswitch")
+        .send_json(serde_json::json!({
+            "description": "ccswitch-export (delete after use)",
+            "public": false,
+            "files": {
+                "ccswitch.blob": { "content": encrypted }
+            }
+        }))
+        .context("Failed to create GitHub Gist")?;
+
+    let json_resp: serde_json::Value = resp.into_json().context("Invalid JSON from gist API")?;
+    let gist_id = json_resp["id"]
+        .as_str()
+        .context("Missing 'id' in gist creation response")?;
+
+    println!(
+        "\n  {}  Uploaded — import with:\n\n      {}\n",
+        "✓".green().bold(),
+        format!("ccswitch import --gist {}", gist_id).cyan().bold()
+    );
+
+    Ok(())
+}
+
 // ── interactive pickers ───────────────────────────────────────────────────────
 
-/// Print the account list and ask the user which accounts to export.
-/// Returns the resolved account numbers.
 fn pick_accounts_interactive(seq: &crate::sequence::SequenceFile) -> Result<Vec<u32>> {
     use std::io::Write;
 
-    // Print account list.
     println!("  {}\n", "Accounts:".bold());
     for &num in &seq.sequence {
         let Some(entry) = seq.accounts.get(&num.to_string()) else {
@@ -197,8 +309,6 @@ fn pick_accounts_interactive(seq: &crate::sequence::SequenceFile) -> Result<Vec<
     Ok(vec![num])
 }
 
-/// Ask whether to copy to clipboard or write to a file.
-/// Returns true if the user chose file.
 fn pick_destination_interactive() -> bool {
     use std::io::Write;
 
@@ -218,12 +328,10 @@ fn pick_destination_interactive() -> bool {
 
 // ── clipboard / file helpers ──────────────────────────────────────────────────
 
-/// Try to copy `blob` to the system clipboard. Returns true on success.
 fn copy_to_clipboard(blob: &str) -> bool {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
-    // Candidates: (binary, args)
     #[cfg(target_os = "macos")]
     let candidates: &[(&str, &[&str])] = &[("pbcopy", &[])];
 
@@ -256,7 +364,6 @@ fn copy_to_clipboard(blob: &str) -> bool {
     false
 }
 
-/// Prompt for a file path and write the blob there (mode 0600).
 fn write_blob_to_file(blob: &str) -> Result<()> {
     use std::io::Write;
 
@@ -272,12 +379,10 @@ fn write_blob_to_file(blob: &str) -> Result<()> {
     std::io::stdin().read_line(&mut input)?;
     let raw = input.trim();
 
-    // Empty input → use the default.
     if raw.is_empty() {
         return write_blob_to_path(blob, &default_path);
     }
 
-    // Expand a leading ~ manually (std::path doesn't do it).
     let path = if let Some(rest) = raw.strip_prefix("~/") {
         dirs::home_dir()
             .context("Cannot find home directory")?
@@ -331,20 +436,14 @@ fn parse_payload(blob: &str) -> Result<ExportPayload> {
     Ok(payload)
 }
 
-pub fn import() -> Result<()> {
-    let raw = rpassword::prompt_password("  Paste export blob: ")
-        .context("Failed to read blob from terminal")?;
-
-    let payload = parse_payload(&raw)?;
-
+/// Apply an already-parsed export payload: write credentials, update sequence, activate account.
+fn do_import(payload: ExportPayload) -> Result<()> {
     sequence::setup_dirs()?;
 
     let mut seq = sequence::load().unwrap_or_default();
 
-    // Map exported num → local num for tracking.
     let mapped_active_local = merge_sequence(&mut seq, &payload.accounts, payload.active_num);
 
-    // Write credentials and config backups.
     for acct in &payload.accounts {
         let local_num = seq.find_by_email(&acct.email).unwrap_or(1);
         credentials::write_backup(local_num, &acct.email, &acct.credentials)
@@ -358,31 +457,23 @@ pub fn import() -> Result<()> {
         {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o600))
-                .with_context(|| format!("Failed to set permissions on {}", config_path.display()))?;
+                .with_context(|| {
+                    format!("Failed to set permissions on {}", config_path.display())
+                })?;
         }
     }
 
-    // Activate the mapped active account.
     let active_acct = payload
         .accounts
         .iter()
-        .find(|a| {
-            // Find the exported account whose local_num matches mapped_active_local.
-            seq.find_by_email(&a.email) == Some(mapped_active_local)
-        })
+        .find(|a| seq.find_by_email(&a.email) == Some(mapped_active_local))
         .context("Cannot find the active account in the import payload")?;
 
     credentials::write_live(&active_acct.credentials)
         .context("Failed to write live credentials")?;
 
-    // Ensure ~/.ccswitchrc is present so CLAUDE_CODE_OAUTH_TOKEN is unset in
-    // new shells — mirrors what do_switch() does after every account activation.
     let _ = credentials::ensure_ccswitchrc();
 
-    // Merge oauthAccount from config backup into ~/.claude/.claude.json.
-    // On a fresh VM neither ~/.claude/.claude.json nor ~/.claude.json exist yet,
-    // so config::load() would fail.  Fall back to an empty object so oauthAccount
-    // is always written and Claude Code recognises the imported account.
     if let Ok(config_json) = serde_json::from_str::<serde_json::Value>(&active_acct.config) {
         if let Some(oauth_account) = config_json.get("oauthAccount").cloned() {
             let mut live_config = crate::config::load().unwrap_or_else(|_| serde_json::json!({}));
@@ -395,7 +486,6 @@ pub fn import() -> Result<()> {
     seq.last_updated = sequence::now_utc();
     sequence::save(&seq)?;
 
-    // Print summary.
     println!();
     for acct in &payload.accounts {
         let local_num = seq.find_by_email(&acct.email).unwrap_or(mapped_active_local);
@@ -421,15 +511,62 @@ pub fn import() -> Result<()> {
     Ok(())
 }
 
+pub fn import() -> Result<()> {
+    let raw = rpassword::prompt_password("  Paste export blob: ")
+        .context("Failed to read blob from terminal")?;
+
+    let payload = parse_payload(&raw)?;
+    do_import(payload)
+}
+
+pub fn import_gist(id: &str) -> Result<()> {
+    let token = gh_token()?;
+
+    let url = format!("https://api.github.com/gists/{}", id);
+
+    let resp = match ureq::get(&url)
+        .set("Authorization", &format!("Bearer {}", token))
+        .set("User-Agent", "ccswitch")
+        .call()
+    {
+        Ok(r) => r,
+        Err(ureq::Error::Status(404, _)) => {
+            anyhow::bail!(
+                "Gist '{}' not found — has it already been deleted or is the ID wrong?",
+                id
+            );
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let json_resp: serde_json::Value = resp.into_json().context("Invalid JSON from gist API")?;
+    let encrypted = json_resp["files"]["ccswitch.blob"]["content"]
+        .as_str()
+        .context("Gist does not contain a 'ccswitch.blob' file — is this a ccswitch gist?")?;
+
+    let passphrase = rpassword::prompt_password("  Passphrase (to decrypt): ")
+        .context("Failed to read passphrase")?;
+
+    let plaintext = decrypt(encrypted, &passphrase)?;
+
+    let blob = STANDARD.encode(&plaintext);
+    let payload = parse_payload(&blob)?;
+
+    do_import(payload)?;
+
+    // Delete the gist only after a successful import.
+    let _ = ureq::delete(&url)
+        .set("Authorization", &format!("Bearer {}", token))
+        .set("User-Agent", "ccswitch")
+        .call();
+
+    println!("  {}  Gist deleted.\n", "✓".green().bold());
+
+    Ok(())
+}
+
 // ── pure helper (also used by tests) ─────────────────────────────────────────
 
-/// Merge imported accounts into an existing (possibly empty) `SequenceFile`.
-///
-/// For each account:
-/// - If the email already exists locally, reuse that number.
-/// - Otherwise allocate `next_account_number()`, insert `AccountEntry`, append to `sequence`.
-///
-/// Returns the local account number that maps to `active_num` in the payload.
 pub(crate) fn merge_sequence(
     seq: &mut crate::sequence::SequenceFile,
     accounts: &[AccountExport],
@@ -454,7 +591,6 @@ pub(crate) fn merge_sequence(
             new_num
         };
 
-        // Append to sequence Vec if not already present.
         if !seq.sequence.contains(&local_num) {
             seq.sequence.push(local_num);
         }
@@ -499,7 +635,6 @@ mod tests {
     #[test]
     fn test_merge_sequence_reuses_existing_email() {
         let mut seq = SequenceFile::default();
-        // Pre-populate with account 5 having the same email.
         seq.accounts.insert(
             "5".to_string(),
             AccountEntry {
@@ -514,10 +649,8 @@ mod tests {
         let accounts = vec![make_account_export(1, "existing@example.com")];
         let active_local = merge_sequence(&mut seq, &accounts, 1);
 
-        // Should reuse local num 5, not allocate a new one.
         assert_eq!(active_local, 5);
         assert!(seq.accounts.contains_key("5"));
-        // sequence should not have duplicates.
         assert_eq!(seq.sequence.iter().filter(|&&n| n == 5).count(), 1);
     }
 
@@ -526,12 +659,9 @@ mod tests {
         let mut seq = SequenceFile::default();
         let accounts = vec![make_account_export(1, "dup@example.com")];
 
-        // First import.
         merge_sequence(&mut seq, &accounts, 1);
-        // Second import of the same account.
         merge_sequence(&mut seq, &accounts, 1);
 
-        // Still only one entry.
         assert_eq!(seq.sequence.iter().filter(|&&n| n == 1).count(), 1);
         assert_eq!(seq.accounts.len(), 1);
     }
@@ -555,16 +685,11 @@ mod tests {
         assert_eq!(restored.version, payload.version);
         assert_eq!(restored.active_num, payload.active_num);
         assert_eq!(restored.accounts[0].email, payload.accounts[0].email);
-        assert_eq!(
-            restored.format_fingerprint,
-            payload.format_fingerprint
-        );
+        assert_eq!(restored.format_fingerprint, payload.format_fingerprint);
     }
 
     #[test]
     fn test_import_version_mismatch_returns_error() {
-        // Build a payload with version 99, encode it, then run it through
-        // parse_payload() to verify the version guard actually fires.
         let payload = ExportPayload {
             version: 99,
             exported_at: "2026-03-03T12:00:00Z".to_string(),
@@ -581,5 +706,39 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Unsupported export version 99"));
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let plaintext = b"hello, this is a secret payload!";
+        let passphrase = "correct-horse-battery-staple";
+        let encoded = encrypt(plaintext, passphrase).unwrap();
+        let decrypted = decrypt(&encoded, passphrase).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_decrypt_wrong_passphrase_fails() {
+        let plaintext = b"secret credential data";
+        let encoded = encrypt(plaintext, "correct-passphrase").unwrap();
+        let result = decrypt(&encoded, "wrong-passphrase");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Decryption failed"));
+    }
+
+    #[test]
+    fn test_encrypt_produces_different_ciphertext_each_time() {
+        let plaintext = b"same input";
+        let passphrase = "same passphrase";
+        let enc1 = encrypt(plaintext, passphrase).unwrap();
+        let enc2 = encrypt(plaintext, passphrase).unwrap();
+        // Random salt + nonce means output must differ.
+        assert_ne!(enc1, enc2);
+        // Both must decrypt correctly.
+        assert_eq!(decrypt(&enc1, passphrase).unwrap(), plaintext);
+        assert_eq!(decrypt(&enc2, passphrase).unwrap(), plaintext);
     }
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -555,12 +555,19 @@ pub fn import_gist(id: &str) -> Result<()> {
     do_import(payload)?;
 
     // Delete the gist only after a successful import.
-    let _ = ureq::delete(&url)
+    match ureq::delete(&url)
         .set("Authorization", &format!("Bearer {}", token))
         .set("User-Agent", "ccswitch")
-        .call();
-
-    println!("  {}  Gist deleted.\n", "✓".green().bold());
+        .call()
+    {
+        Ok(_) => println!("  {}  Gist deleted.\n", "✓".green().bold()),
+        Err(e) => eprintln!(
+            "  {}  Could not delete gist {} — remove it manually: {}\n",
+            "⚠".yellow().bold(),
+            id,
+            e
+        ),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Closes #28

Adds `--gist` to `export` and `--gist <id>` to `import` so credentials can be relayed via a private GitHub Gist without ever touching a file or clipboard.

**Encryption:** PBKDF2-SHA256 (100k rounds, random 16-byte salt) → 32-byte key → ChaCha20-Poly1305 (random 12-byte nonce). Bundle is `base64(salt ++ nonce ++ ciphertext+tag)`.

**Flow:**
- `ccswitch export --gist` — prompts passphrase, encrypts payload, POSTs a private gist via `gh auth token`, prints `ccswitch import --gist <id>`
- `ccswitch import --gist <id>` — fetches gist, prompts passphrase, decrypts, imports, then DELETEs the gist on success

The gist is ephemeral: it's deleted automatically after a successful import, and the description says "delete after use" in case the user forgets.